### PR TITLE
refactor: Use init name for repo generation

### DIFF
--- a/repo/index.mjs
+++ b/repo/index.mjs
@@ -1,56 +1,65 @@
 export default async function (plop) {
-  plop.setGenerator("repo:dotfiles", {
-    description: "General configuration through .dotfiles",
-    prompts: [],
-    actions: [
+  plop.setGenerator("repo:init", {
+    description: "Init a repo with general configuration",
+    prompts: [
       {
-        type: "addMany",
-        destination: "./",
-        base: "templates",
-        templateFiles: "**/.*",
-        globOptions: { dot: true },
-        verbose: true,
+        type: "checkbox",
+        name: "initOptions",
+        message: "What would you like to initialise?",
+        choices: [
+          { name: ".dotfiles", value: "dotfiles" },
+          { name: "GitHub templates", value: "github" },
+          { name: "Repo documentation", value: "docs" },
+        ],
       },
     ],
-  });
+    actions: function (data) {
+      const actions = [];
 
-  plop.setGenerator("repo:github", {
-    description: "General configuration through .dotfiles",
-    prompts: [],
-    actions: [
-      {
-        type: "addMany",
-        destination: ".github",
-        base: "templates/.github",
-        templateFiles: "**",
-        globOptions: { dot: true },
-        verbose: true,
-      },
-    ],
-  });
+      if (data.initOptions.includes("dotfiles")) {
+        actions.push({
+          type: "addMany",
+          destination: "./",
+          base: "templates",
+          templateFiles: "**/.*",
+          globOptions: { dot: true },
+          verbose: true,
+        });
+      }
 
-  plop.setGenerator("repo:docs", {
-    description: "",
-    prompts: [],
-    actions: [
-      {
-        type: "add",
-        path: "CODEOWNERS",
-        templateFile: "templates/CODEOWNERS",
-        verbose: true,
-      },
-      {
-        type: "add",
-        path: "LICENSE",
-        templateFile: "templates/LICENSE",
-        verbose: true,
-      },
-      {
-        type: "add",
-        path: "SECURITY.md",
-        templateFile: "templates/SECURITY.md",
-        verbose: true,
-      },
-    ],
+      if (data.initOptions.includes("dotfiles")) {
+        actions.push({
+          type: "addMany",
+          destination: ".github",
+          base: "templates/.github",
+          templateFiles: "**",
+          globOptions: { dot: true },
+          verbose: true,
+        });
+      }
+
+      if (data.initOptions.includes("docs")) {
+        actions.push({
+          type: "add",
+          path: "CODEOWNERS",
+          templateFile: "templates/CODEOWNERS",
+          verbose: true,
+        });
+        actions.push({
+          type: "add",
+          path: "LICENSE",
+          templateFile: "templates/LICENSE",
+          verbose: true,
+        });
+        actions.push({
+          type: "add",
+          path: "SECURITY.md",
+          templateFile: "templates/SECURITY.md",
+          verbose: true,
+        });
+      }
+
+      return actions;
+    },
   });
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Refactor `repo: dotfiles/github/docs` to use `repo:init` and checkboxes in CLI


<!-- Describe the changes in detail - the "what"-->

### Why did it change

Naming standards have been decided with `init` being used for things that are created in an empty folder.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
