### PR TITLE
chore: removed prettier from package.json in template.

### DIFF
--- a/lambda/templates/lambdas/package.json.hbs
+++ b/lambda/templates/lambdas/package.json.hbs
@@ -4,10 +4,8 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "lint:prettier": "prettier --check ..",
-    "lint:prettier-fix": "npx prettier --write ..",
+    "lint:prettier-fix": "pre-commit run prettier --all-files",
     "lint:eslint": "eslint ..",
-    "lint": "npm run lint:prettier && npm run lint:eslint",
     "compile": "tsc",
     "unit": "jest --config=jest.config.ts",
     "test": "npm run compile && npm run unit"
@@ -32,7 +30,6 @@
     "esbuild-jest": "0.5.0",
     "jest": "29.5.0",
     "ts-jest": "29.1.0",
-    "prettier": "2.8.7",
     "ts-node": "10.9.1",
     "typescript": "5.0.4"
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Removed prettier from package.json

### Why did it change

- pre-commit already uses prettier so redundant to have it in npm as well

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
