### PR TITLE
BAU: Repo rename and org change

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@alphagov/di-ipv-orange-cri-maintainers
+* @govuk-one-login/cri-orange-team @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team-leads # Team ownership with break-glass overrides

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# di-ipv-cri-templates
+# ipv-cri-templates
 
 Micro-templates for creating and developing Digital Identity Credential Issuers
 
@@ -15,7 +15,7 @@ npm install -g plop
 From inside the directory to apply the templates
 
 ```bash
-plop --plopfile ../di-ipv-cri-templates/plopfile.mjs --dest .
+plop --plopfile ../ipv-cri-templates/plopfile.mjs --dest .
 
 ```
 

--- a/frontend/templates/cucumber/tests/browser/README.md.hbs
+++ b/frontend/templates/cucumber/tests/browser/README.md.hbs
@@ -1,4 +1,4 @@
-# di-ipv-cri-{{ kebabCase criName }}-front-tests
+# ipv-cri-{{ kebabCase criName }}-front-tests
 
 {{ titleCase criName }} Credential Issuer Frontend Tests is a test suite designed to run against the webserver in the root of this repository.
 

--- a/frontend/templates/cucumber/tests/browser/package.json.hbs
+++ b/frontend/templates/cucumber/tests/browser/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "di-ipv-cri-{{ kebabCase criName }}-front-tests",
+  "name": "ipv-cri-{{ kebabCase criName }}-front-tests",
   "version": "1.0.0",
   "description": "Browser tests for the frontend of the {{ titleCase criName }} Credential Issuer",
   "scripts": {

--- a/frontend/templates/express/README.md.hbs
+++ b/frontend/templates/express/README.md.hbs
@@ -1,20 +1,20 @@
-# di-ipv-cri-{{ kebabCase criName }}-front
+# ipv-cri-{{ kebabCase criName }}-front
 
-[![Github Action: Unit Tests](https://github.com/alphagov/di-ipv-cri-{{ kebabCase criName}}-front/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/alphagov/di-ipv-cri-{{ kebabCase criName }}-front/actions/workflows/unit-tests.yml?query=branch%3Amain)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=alphagov_di-ipv-cri-{{ kebabCase criName}}-front&metric=coverage)](https://sonarcloud.io/summary/new_code?id=alphagov_di-ipv-cri-{{ kebabCase criName }}-front)
+[![Github Action: Unit Tests](https://github.com/govuk-one-login/ipv-cri-{{ kebabCase criName}}-front/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/govuk-one-login/ipv-cri-{{ kebabCase criName }}-front/actions/workflows/unit-tests.yml?query=branch%3Amain)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ipv-cri-{{ kebabCase criName}}-front&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ipv-cri-{{ kebabCase criName }}-front)
 
-> Note: This repository is templated as part of [di-ipv-cri-templates](https://github.com/alphagov/di-ipv-cri-templates), and any substational changes that can be shared should be included back into that repository for re-use elsewhere
+> Note: This repository is templated as part of [ipv-cri-templates](https://github.com/govuk-one-login/ipv-cri-templates), and any substational changes that can be shared should be included back into that repository for re-use elsewhere
 
 {{ titleCase criName }} Credential Issuer Frontend is a Credential Issuer as part of the GOV.UK One Login programme.
 
 There are two main repositories that comprise this credential issuer:
 
 - This is the website used for displaying the {{ titleCase criName }} Credential Issuer.
-- There is a related [api repository](https://github.com/alphagov/di-ipv-cri-{{ kebabCase criName }}-api) that contains the backend API that provides all the data interaction consumed
+- There is a related [api repository](https://github.com/govuk-one-login/ipv-cri-{{ kebabCase criName }}-api) that contains the backend API that provides all the data interaction consumed
 
 For frontend specific work there are the following repositories:
 
-- There is a [shared library repository](https://github.com/alphagov/di-ipv-cri-common-express)
+- There is a [shared library repository](https://github.com/govuk-one-login/ipv-cri-common-express)
 - This contains Express middleware, shared JavaScript and Sass files, and shared templates
 
 ## Quick Start
@@ -32,7 +32,7 @@ The following quickstart process details how to install and run the CRI frontend
 1. Clone repository and change directory:
 
 ```
-git clone https://github.com/alphagov/di-ipv-cri-{{ kebabCase criName }}-front && cd di-ipv-cri-{{ kebabCase criName }}-front
+git clone https://github.com/govuk-one-login/ipv-cri-{{ kebabCase criName }}-front && cd ipv-cri-{{ kebabCase criName }}-front
 ```
 
 2. Install node dependencies:
@@ -95,7 +95,7 @@ This is configured in the frontend application using the `API_BASE_URL` environm
 
 ### Mock API
 
-A standalone mock of the [api](https://github.com/alphagov/di-ipv-cri-{{ kebabCase criName }}-api) is provided using a combination of the API's OpenAPI config and hand-crafted Imposter scenarios.
+A standalone mock of the [api](https://github.com/govuk-one-login/ipv-cri-{{ kebabCase criName }}-api) is provided using a combination of the API's OpenAPI config and hand-crafted Imposter scenarios.
 
 More details on how to run this are in the [Imposter folder](./tests/imposter/).
 

--- a/frontend/templates/express/src/README.md
+++ b/frontend/templates/express/src/README.md
@@ -27,9 +27,9 @@ They can have a variety of different parts, in either a root file, or a folder w
 - `steps.js` - Step definitions
 - `validators/` - Validator functions
 
-## di-ipv-cri-common-express
+## ipv-cri-common-express
 
-[common-express](https://github.com/alphagov/di-ipv-cri-common-express/) is a shared library used by Credential Issuer frontends for:
+[common-express](https://github.com/govuk-one-login/ipv-cri-common-express/) is a shared library used by Credential Issuer frontends for:
 
 - UI components
 - frontend assets

--- a/frontend/templates/express/src/app.js.hbs
+++ b/frontend/templates/express/src/app.js.hbs
@@ -6,7 +6,7 @@ const session = require("express-session");
 const AWS = require("aws-sdk");
 const DynamoDBStore = require("connect-dynamodb")(session);
 
-const commonExpress = require("@govuk-one-login/di-ipv-cri-common-express");
+const commonExpress = require("@govuk-one-login/ipv-cri-common-express");
 
 const setHeaders = commonExpress.lib.headers;
 const setScenarioHeaders = commonExpress.lib.scenarioHeaders;
@@ -15,13 +15,13 @@ const setAxiosDefaults = commonExpress.lib.axios;
 const { setAPIConfig, setOAuthPaths } = require("./lib/settings.js");
 const {
   setGTM,
-} = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/settings");
+} = require("@govuk-one-login/ipv-cri-common-express/src/lib/settings");
 const {
   getGTM,
-} = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/locals");
+} = require("@govuk-one-login/ipv-cri-common-express/src/lib/locals");
 const {
   setI18n,
-} = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/i18next");
+} = require("@govuk-one-login/ipv-cri-common-express/src/lib/i18next");
 
 const {
   API,
@@ -58,7 +58,7 @@ const sessionConfig = {
   ...(SESSION_TABLE_NAME && { sessionStore: dynamoDBSessionStore }),
 };
 
-const helmetConfig = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/helmet");
+const helmetConfig = require("@govuk-one-login/ipv-cri-common-express/src/lib/helmet");
 
 const { app, router } = setup({
   config: { APP_ROOT: __dirname },
@@ -74,7 +74,7 @@ const { app, router } = setup({
   publicDirs: ["../dist/public"],
   views: [
     path.resolve(
-      path.dirname(require.resolve("@govuk-one-login/di-ipv-cri-common-express")),
+      path.dirname(require.resolve("@govuk-one-login/ipv-cri-common-express")),
       "components"
     ),
     "views",

--- a/frontend/templates/npm/package.json.hbs
+++ b/frontend/templates/npm/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "di-ipv-cri-{{ kebabCase criName }}-front",
+  "name": "ipv-cri-{{ kebabCase criName }}-front",
   "version": "1.0.0",
   "description": "Frontend for the {{ titleCase criName }} Credential Issuer",
   "main": "index.js",
@@ -10,12 +10,12 @@
     "build": "npm run build:sass && npm run build:js && npm run copy-assets",
     "build:js": "npm run build:js:application && npm run build:js:cookies && npm run build:js:all",
     "build:js:all": "mkdir -p dist/public/javascripts; uglifyjs node_modules/govuk-frontend/govuk/all.js node_modules/hmpo-components/all.js --beautify -o dist/public/javascripts/all.js",
-    "build:js:application": "mkdir -p dist/public/javascripts; uglifyjs src/assets/javascripts/application.js  node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/application.js --beautify -o dist/public/javascripts/application.js",
-    "build:js:cookies": "mkdir -p dist/public/javascripts; uglifyjs node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/cookies.js --beautify -o dist/public/javascripts/cookies.js",
+    "build:js:application": "mkdir -p dist/public/javascripts; uglifyjs src/assets/javascripts/application.js  node_modules/@govuk-one-login/ipv-cri-common-express/src/assets/javascript/application.js --beautify -o dist/public/javascripts/application.js",
+    "build:js:cookies": "mkdir -p dist/public/javascripts; uglifyjs node_modules/@govuk-one-login/ipv-cri-common-express/src/assets/javascript/cookies.js --beautify -o dist/public/javascripts/cookies.js",
     "build:js:minify": "uglifyjs src/assets/javascript/application.js -o src/assets/javascript/application.js -c -m && uglifyjs src/assets/javascript/cookies.js -o src/assets/javascript/cookies.js -c -m",
     "build:sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
     "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts",
-    "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js ../../../../src/locales/",
+    "check-translation": "node node_modules/@govuk-one-login/ipv-cri-common-express/scripts/checkTranslations.js ../../../../src/locales/",
     "pre-commit": "pre-commit run --all-files --show-diff-on-failure",
     "pc": "npm run pre-commit",
     "test": "jest"
@@ -35,7 +35,7 @@
     "uglify-js": "3.17.4"
   },
   "dependencies": {
-    "@govuk-one-login/di-ipv-cri-common-express": "3.0.0",
+    "@govuk-one-login/ipv-cri-common-express": "3.0.0",
     "aws-sdk": "2.1376.0",
     "axios": "1.4.0",
     "cfenv": "1.2.4",

--- a/lambda/templates/lambdas/package.json.hbs
+++ b/lambda/templates/lambdas/package.json.hbs
@@ -12,7 +12,7 @@
     "pc": "npm run pre-commit",
     "compile": "tsc"
   },
-  "author": "alphagov",
+  "author": "GOV.UK One Login",
   "license": "MIT",
   "dependencies": {
     "@aws-lambda-powertools/commons": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
-  "name": "di-ipv-cri-templates",
+  "name": "ipv-cri-templates",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "di-ipv-cri-templates",
-      "version": "0.0.1",
+      "name": "ipv-cri-templates",
       "license": "MIT",
       "devDependencies": {
         "plop": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,25 +1,21 @@
 {
-  "name": "di-ipv-cri-templates",
-  "version": "0.0.1",
+  "name": "ipv-cri-templates",
   "description": "Micro-templates for creating and developing Digital Identity Credential Issuers",
-  "main": "index.js",
-  "type": "module",
+  "homepage": "https://github.com/govuk-one-login/ipv-cri-templates#readme",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govuk-one-login/ipv-cri-templates.git"
+  },
+  "bugs": {
+    "url": "https://github.com/govuk-one-login/ipv-cri-templates/issues"
+  },
   "scripts": {
     "plop": "plop --plopfile plopfile.mjs",
     "test": "echo \"Error: no test specified\" && exit 1",
     "pre-commit": "pre-commit run --all-files --show-diff-on-failure",
     "pc": "npm run pre-commit"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/alphagov/di-ipv-cri-templates.git"
-  },
-  "author": "",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/alphagov/di-ipv-cri-templates/issues"
-  },
-  "homepage": "https://github.com/alphagov/di-ipv-cri-templates#readme",
   "devDependencies": {
     "plop": "^4.0.0"
   }

--- a/repo/templates/CODEOWNERS
+++ b/repo/templates/CODEOWNERS
@@ -1,1 +1,1 @@
-@alphagov/di-ipv-orange-cri-maintainers
+* @govuk-one-login/cri-orange-team @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team-leads # Team ownership with break-glass overrides


### PR DESCRIPTION
OJ-1984: Repo rename and org change after the migration

Replace `alphagov/di-ipv-cri-templates` with `govuk-one-login/ipv-cri-templates`