### PR TITLE
BAU: Minor formatting and SAM template fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-case-conflict
       - id: detect-private-key
       - id: end-of-file-fixer
+        exclude: lambda/templates/infrastructure/template.hbs
       - id: no-commit-to-branch
       - id: trailing-whitespace
   - repo: https://github.com/Yelp/detect-secrets

--- a/frontend/index.mjs
+++ b/frontend/index.mjs
@@ -1,3 +1,5 @@
+import path from "path";
+
 export default async function (plop) {
   plop.setGenerator("frontend:init", {
     description: "Init a FE with general configuration",
@@ -21,7 +23,7 @@ export default async function (plop) {
       },
     ],
     actions: function (data) {
-      data.criName = plop.getDestBasePath().split("/").slice(-1)[0];
+      data.criName = path.basename(plop.getDestBasePath());
       const actions = [];
 
       if (data.initOptions.includes("dotfiles")) {

--- a/frontend/templates/cucumber/.github/workflows/browser.yml
+++ b/frontend/templates/cucumber/.github/workflows/browser.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Stop Docker
         run: docker compose down
         working-directory: tests/docker
-        if: ${{ always() }}
+        if: $\{{ always() }}

--- a/frontend/templates/express/src/app.js.hbs
+++ b/frontend/templates/express/src/app.js.hbs
@@ -74,9 +74,9 @@ const { app, router } = setup({
   publicDirs: ["../dist/public"],
   views: [
     path.resolve(
-    path.dirname(
-      require.resolve("@govuk-one-login/di-ipv-cri-common-express")
-    ),
+      path.dirname(
+        require.resolve("@govuk-one-login/di-ipv-cri-common-express")
+      ),
       "components"
     ),
     "views",

--- a/frontend/templates/npm/package.json.hbs
+++ b/frontend/templates/npm/package.json.hbs
@@ -39,7 +39,7 @@
     "uglify-js": "3.17.4"
   },
   "dependencies": {
-    "@govuk-one-login/di-ipv-cri-common-express": "3.0.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "3.2.0",
     "aws-sdk": "2.1376.0",
     "axios": "1.4.0",
     "cfenv": "1.2.4",

--- a/lambda/index.mjs
+++ b/lambda/index.mjs
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 export default async function (plop) {
   plop.setGenerator("lambda:workflow:tests", {
     description: "General configuration for lambdas",
@@ -24,7 +26,7 @@ export default async function (plop) {
       },
     ],
     actions: function (data) {
-      data.criName = plop.getDestBasePath().split("/").slice(-1)[0];
+      data.criName = path.basename(plop.getDestBasePath());
 
       return [
         {

--- a/lambda/templates/infrastructure/output-fragment.hbs
+++ b/lambda/templates/infrastructure/output-fragment.hbs
@@ -1,9 +1,9 @@
   {{ pascalCase lambdaName }}FunctionURLEndpoint:
-    Description: FURLFunction function name
+    Description: Endpoint URL for {{ pascalCase lambdaName }} function
     Value: !GetAtt {{ pascalCase lambdaName }}FunctionUrl.FunctionUrl
   {{ pascalCase lambdaName }}Function:
-    Description: "{{ pascalCase lambdaName }} Lambda Function ARN"
+    Description: {{ pascalCase lambdaName }} Lambda Function ARN
     Value: !GetAtt {{ pascalCase lambdaName }}Function.Arn
   {{ pascalCase lambdaName }}FunctionIamRole:
-    Description: "Implicit IAM Role created for {{ pascalCase lambdaName }} function"
+    Description: Implicit IAM Role created for {{ pascalCase lambdaName }} function
     Value: !GetAtt {{ pascalCase lambdaName }}FunctionRole.Arn

--- a/lambda/templates/infrastructure/resource-fragment.hbs
+++ b/lambda/templates/infrastructure/resource-fragment.hbs
@@ -1,17 +1,13 @@
   {{ pascalCase lambdaName }}Function:
     Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
     Properties:
       CodeUri: ../lambdas/{{ kebabCase lambdaName }}
-      Handler: {{ kebabCase lambdaName }}-handler.lambdaHandler
+      Handler: src/{{ kebabCase lambdaName }}-handler.lambdaHandler
       FunctionUrlConfig:
         AuthType: AWS_IAM
         Cors:
           AllowOrigins: ["*"]
-    Metadata:
-      BuildMethod: esbuild
-      BuildProperties:
-        Minify: true
-        Target: "es2020"
-        Sourcemap: true
-        EntryPoints:
-          - src/{{ kebabCase lambdaName }}-handler.ts

--- a/lambda/templates/infrastructure/resource-fragment.hbs
+++ b/lambda/templates/infrastructure/resource-fragment.hbs
@@ -7,6 +7,8 @@
     Properties:
       CodeUri: ../lambdas/{{ kebabCase lambdaName }}
       Handler: src/{{ kebabCase lambdaName }}-handler.lambdaHandler
+      CodeSigningConfigArn:
+        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
       FunctionUrlConfig:
         AuthType: AWS_IAM
         Cors:

--- a/lambda/templates/infrastructure/template.hbs
+++ b/lambda/templates/infrastructure/template.hbs
@@ -2,14 +2,25 @@ AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: "Digital Identity {{ kebabCase criName }}"
 
+Parameters:
+  CodeSigningConfigArn:
+    Type: String
+    Default: ""
+  PermissionsBoundary:
+    Type: String
+    Default: ""
+
+Conditions:
+  EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
+  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
+
 Globals:
   Function:
     Timeout: 3
     Runtime: nodejs18.x
     Architectures: [arm64]
-    PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
-    CodeSigningConfigArn: !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+    PermissionsBoundary:
+      !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
 
 Resources:
-
 Outputs:

--- a/repo/index.mjs
+++ b/repo/index.mjs
@@ -1,3 +1,5 @@
+import path from "path";
+
 export default async function (plop) {
   plop.setGenerator("repo:init", {
     description: "Init a repo with general configuration",
@@ -14,7 +16,6 @@ export default async function (plop) {
       },
     ],
     actions: function (data) {
-      data.criName = plop.getDestBasePath().split("/").slice(-1)[0];
       const actions = [];
 
       if (data.initOptions.includes("dotfiles")) {


### PR DESCRIPTION
**Use default values for SAM function metadata**

`Minify: true` and `Target: es2020` are the default values so they don't need to be specified in the template. `EntryPoints` is the same as `Handler` so it doesn't need to be duplicated

**Use a better way to get CRI name from destination path**

`criName` is not used in the repo generator, so remove it.
Remove unused ignore files - files to ignore are already specified in the relevant config files.

**Add code signing and permissions boundary params to the lambda template**

`CodeSigningConfigArn` is not an officially supported property of the Globals section, so move it to the lambda template.

Reference: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-template-anatomy-globals.html#sam-specification-template-anatomy-globals-supported-resources-and-properties

---

- Fix an output name and use consistent quotes in the infra template
- FIX: Escape handlebar syntax in GHA template
  Plop treats this as a template and fails - escaping the double braces copies the contents directly, which is what we want.

_Ticket OJ-1984_