### PR TITLE
BAU: Add ESlint and prettier config at the root of the repo and enable ESLint plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,3 @@ repos:
     rev: v3.0.3
     hooks:
       - id: prettier
-        exclude: package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 lambda/templates/lambdas/*
+package-lock.json
 **/*.hbs

--- a/frontend/templates/dotfiles/.eslintignore
+++ b/frontend/templates/dotfiles/.eslintignore
@@ -1,2 +1,0 @@
-wallaby.conf.js
-dist

--- a/frontend/templates/dotfiles/.eslintrc.js
+++ b/frontend/templates/dotfiles/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   env: {
     node: true,
     es6: true,
@@ -10,8 +11,8 @@ module.exports = {
     expect: true,
     setupDefaultMocks: "readonly",
   },
-  root: true,
-  extends: ["eslint:recommended", "prettier"],
+  extends: ["eslint:recommended", "plugin:prettier/recommended"],
+  ignorePatterns: ["node_modules", "build", "dist", "coverage"],
   rules: {
     "no-console": 2,
     "padding-line-between-statements": [

--- a/frontend/templates/npm/package.json.hbs
+++ b/frontend/templates/npm/package.json.hbs
@@ -6,7 +6,6 @@
   "scripts": {
     "start": "node src/app.js",
     "dev": "NODE_ENV=development nodemon src/app.js",
-    "lint": "eslint",
     "build": "npm run build:sass && npm run build:js && npm run copy-assets",
     "build:js": "npm run build:js:application && npm run build:js:cookies && npm run build:js:all",
     "build:js:all": "mkdir -p dist/public/javascripts; uglifyjs node_modules/govuk-frontend/govuk/all.js node_modules/hmpo-components/all.js --beautify -o dist/public/javascripts/all.js",
@@ -18,6 +17,8 @@
     "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js ../../../../src/locales/",
     "pre-commit": "pre-commit run --all-files --show-diff-on-failure",
     "pc": "npm run pre-commit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "unit": "jest --silent",
     "test": "npm run unit",
     "test:coverage": "npm run unit -- --coverage"
@@ -32,6 +33,7 @@
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-prettier": "5.0.0",
     "jest": "29.7.0",
+    "prettier": "^3.0.3",
     "nodemon": "3.0.1",
     "sass": "1.66.1",
     "uglify-js": "3.17.4"

--- a/lambda/templates/config/.eslintrc.js
+++ b/lambda/templates/config/.eslintrc.js
@@ -1,8 +1,14 @@
 module.exports = {
+  root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    ecmaVersion: 2022, // Allows for the parsing of modern ECMAScript features
+    tsconfigRootDir: __dirname,
+    project: ["./tsconfig.eslint.json", "lambdas/**/tsconfig.json"],
     sourceType: "module",
+    ecmaVersion: 2022,
+    ecmaFeatures: {
+      impliedStrict: true,
+    },
   },
   env: {
     node: true,
@@ -13,11 +19,19 @@ module.exports = {
     sinon: true,
     expect: true,
   },
-  root: true,
+  plugins: ["@typescript-eslint"],
   extends: [
     "eslint:recommended",
-    "prettier",
+    "plugin:prettier/recommended",
     "plugin:@typescript-eslint/recommended",
+  ],
+  ignorePatterns: [
+    "node_modules",
+    ".aws-sam",
+    "build",
+    "dist",
+    "dotenv",
+    "coverage",
   ],
   rules: {
     "no-console": 2,

--- a/lambda/templates/config/package.json.hbs
+++ b/lambda/templates/config/package.json.hbs
@@ -2,6 +2,8 @@
   "name": "{{ kebabCase criName }}",
   "description": "",
   "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "unit": "jest --silent",
     "test": "npm run unit",
     "test:coverage": "npm run unit -- --coverage",
@@ -10,8 +12,14 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",
+    "@typescript-eslint/eslint-plugin": "^6.7.4",
+    "@typescript-eslint/parser": "^6.7.4",
     "esbuild-jest": "^0.5.0",
+    "eslint": "^8.50.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.7.0",
+    "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
     "ts-node": "10.9.1"
   }

--- a/lambda/templates/config/tsconfig.eslint.json
+++ b/lambda/templates/config/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  // Additional paths to lint not included by other tsconfig.json files
+  "include": ["**/**/.*.js", "**/**/*.js", "**/**/*.ts"]
+}

--- a/lambda/templates/lambdas/.eslintignore
+++ b/lambda/templates/lambdas/.eslintignore
@@ -1,4 +1,0 @@
-node_modules
-.aws-sam
-build
-dotenv

--- a/lambda/templates/lambdas/package.json.hbs
+++ b/lambda/templates/lambdas/package.json.hbs
@@ -4,8 +4,8 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "lint:prettier-fix": "pre-commit run prettier --all-files",
-    "lint:eslint": "eslint .",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "unit": "jest --silent",
     "test": "npm run unit",
     "test:coverage": "npm run unit -- --coverage",
@@ -24,11 +24,6 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.114",
-    "@typescript-eslint/eslint-plugin": "5.10.2",
-    "@typescript-eslint/parser": "5.10.2",
-    "eslint": "8.8.0",
-    "eslint-config-prettier": "8.3.0",
-    "eslint-plugin-prettier": "4.0.0",
     "typescript": "5.0.4"
   }
 }

--- a/lambda/templates/lambdas/tsconfig.json
+++ b/lambda/templates/lambdas/tsconfig.json
@@ -14,5 +14,6 @@
     "outDir": "./build/",
     "noImplicitAny": true
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "build", "coverage"],
+  "include": ["src", "tests"]
 }

--- a/repo/templates/.pre-commit-config.yaml
+++ b/repo/templates/.pre-commit-config.yaml
@@ -20,4 +20,3 @@ repos:
     rev: v3.0.3
     hooks:
       - id: prettier
-        exclude: package-lock.json

--- a/repo/templates/.prettierignore
+++ b/repo/templates/.prettierignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/repo/templates/.prettierrc.json
+++ b/repo/templates/.prettierrc.json
@@ -1,1 +1,3 @@
-{}
+{
+  "trailingComma": "es5"
+}


### PR DESCRIPTION
**Add ESlint and prettier config to the root of the repo and enable ESlint plugins**

Use one config for ESlint and prettier in the root of the repo without the need to duplicate the config files for each lambda. All lambdas are automatically added to the parser by configuring the ESlint project property.

Add a `package.json` file at the root of the repo so ESlint, prettier and the plugins can be installed once and re-used for all lambdas - npm no longer needs to duplicate them in each sub-project and each lambda can now have a slimmer dependency file.

Enable the prettier and TypeScript plugins in ESlint. These plugins were already installed in `package.json` but they weren't used, as they need to be explicitly added to ESlint config.

With the plugins enabled, ESlint highlights prettier rules in the IDE and fixes the errors if the `--fix` flag is used whilst the TypeScript plugin allows ESlint to apply the recommended TypeScript rules.

Update the linting scripts - prettier doesn't need to be run in addition to ESlint as ESlint runs prettier rules with the plugin now in use. In addition, all lambdas can be linted at once with one invocation from the root of the repo, or individually when the linter is invoked from a lambda's root dir.

Exclude `package-lock.json` by default (using the prettier ignore file).

_Ticket OJ-1984_