### PR TITLE
BAU: Clean up package.json files

### DIFF
--- a/frontend/templates/cucumber/tests/browser/package.json.hbs
+++ b/frontend/templates/cucumber/tests/browser/package.json.hbs
@@ -1,12 +1,9 @@
 {
   "name": "ipv-cri-{{ kebabCase criName }}-front-tests",
-  "version": "1.0.0",
   "description": "Browser tests for the frontend of the {{ titleCase criName }} Credential Issuer",
   "scripts": {
     "test:browser": "cucumber-js"
   },
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "@cucumber/cucumber": "9.5.1",
     "axios": "1.5.0",

--- a/frontend/templates/npm/package.json.hbs
+++ b/frontend/templates/npm/package.json.hbs
@@ -1,8 +1,6 @@
 {
   "name": "ipv-cri-{{ kebabCase criName }}-front",
-  "version": "1.0.0",
   "description": "Frontend for the {{ titleCase criName }} Credential Issuer",
-  "main": "index.js",
   "scripts": {
     "start": "node src/app.js",
     "dev": "NODE_ENV=development nodemon src/app.js",
@@ -23,8 +21,6 @@
     "test": "npm run unit",
     "test:coverage": "npm run unit -- --coverage"
   },
-  "author": "",
-  "license": "MIT",
   "devDependencies": {
     "chai": "4.3.8",
     "chai-as-promised": "7.1.1",

--- a/lambda/templates/lambdas/package.json.hbs
+++ b/lambda/templates/lambdas/package.json.hbs
@@ -1,8 +1,6 @@
 {
   "name": "{{ kebabCase lambdaName }}",
-  "version": "1.0.0",
   "description": "",
-  "main": "app.js",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -13,8 +11,6 @@
     "pc": "npm run pre-commit",
     "compile": "tsc"
   },
-  "author": "GOV.UK One Login",
-  "license": "MIT",
   "dependencies": {
     "@aws-lambda-powertools/commons": "1.8.0",
     "@aws-lambda-powertools/logger": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "ipv-cri-templates",
-      "license": "MIT",
       "devDependencies": {
         "jest": "^29.7.0",
         "plop": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "ipv-cri-templates",
   "description": "Micro-templates for creating and developing Digital Identity Credential Issuers",
   "homepage": "https://github.com/govuk-one-login/ipv-cri-templates#readme",
-  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/govuk-one-login/ipv-cri-templates.git"


### PR DESCRIPTION
We don't publish npm packages (except for one repo), so we don't need to specify the licence, author, version and main properties.
