### PR TITLE
OJ-1960: Add SonarCloud workflow to lambda repos

### DIFF
--- a/lambda/templates/workflows/sonarcloud.yml
+++ b/lambda/templates/workflows/sonarcloud.yml
@@ -1,0 +1,36 @@
+name: SonarCloud
+
+on:
+  workflow_call:
+    secrets:
+      github-token: { required: true }
+      sonar-token: { required: true }
+
+permissions: read-all
+
+concurrency:
+  group: sonarcloud-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get coverage results
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: coverage
+
+      - name: Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+          SONAR_TOKEN: ${{ secrets.sonar-token }}


### PR DESCRIPTION
Add a reusable SonarCloud workflow to repos.

The workflow will not run as added in this PR - the work to use it will be added in a subsequent PR.