### PR TITLE
BAU: Update the template repo with changes from other repos

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,6 @@ jobs:
       security-events: write
     steps:
       - name: Run a CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@b2b6fc5df355031fd08cef37fa13a93670a45899
+        uses: govuk-one-login/github-actions/code-quality/codeql@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           languages: javascript-typescript

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@b2b6fc5df355031fd08cef37fa13a93670a45899
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           all-files: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,0 @@
-# Security Policy
-
-Vulnerability Disclosure Policy - https://www.gov.uk/help/report-vulnerability

--- a/api/index.mjs
+++ b/api/index.mjs
@@ -1,29 +1,30 @@
+import path from "path";
+
 export default async function (plop) {
   plop.setGenerator("api:init", {
-    prompts: [
-      {
-        type: "input",
-        name: "criName",
-        message: "CRI Name?",
-      },
-    ],
-    actions: [
-      {
-        type: "addMany",
-        destination: "./infrastructure",
-        base: "templates/infrastructure",
-        templateFiles: "**",
-        verbose: true,
-        force: false,
-        skipIfExists: true,
-      },
-      {
-        type: "add",
-        path: "deploy.sh",
-        templateFile: "templates/deploy.sh.hbs",
-        verbose: true,
-        skipIfExists: true,
-      },
-    ],
+    prompts: [],
+    actions: function (data) {
+      data.criName = path.basename(plop.getDestBasePath());
+      data.criNameShort = data.criName.replace(/^ipv-cri-/, "");
+
+      return [
+        {
+          type: "addMany",
+          destination: "./infrastructure",
+          base: "templates/infrastructure",
+          templateFiles: "**",
+          verbose: true,
+          force: false,
+          skipIfExists: true,
+        },
+        {
+          type: "add",
+          path: "deploy.sh",
+          templateFile: "templates/deploy.sh.hbs",
+          verbose: true,
+          force: true,
+        },
+      ];
+    },
   });
 }

--- a/api/templates/deploy.sh.hbs
+++ b/api/templates/deploy.sh.hbs
@@ -1,29 +1,33 @@
 #!/usr/bin/env bash
-set -e
+cd "$(dirname "${BASH_SOURCE[0]}")"
+set -eu
 
-stack_name="$1"
-common_stack_name="${2:-{{ kebabCase criName }}-common-cri-api-local}"
-secret_prefix="${3:-{{ kebabCase criName }}-cri-api}"
+stack_name="${1:-}"
+common_stack_name="${2:-}"
 
-if [ -z "$stack_name" ]
-then
-echo "😱 stack name expected as first argument, e.g. ./deploy {{ kebabCase criName }}-user1"
-exit 1
+if ! [[ "$stack_name" ]]; then
+  [[ $(aws whoami --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
+  stack_name="$user-{{ kebabCase criNameShort }}"
+  echo "» Using stack name '$stack_name'"
 fi
 
-./gradlew clean
 sam validate -t infrastructure/template.yaml
-sam build -t infrastructure/template.yaml
+sam validate -t infrastructure/template.yaml --lint
+
+sam build -t infrastructure/template.yaml --cached --parallel
+
 sam deploy --stack-name "$stack_name" \
-   --no-fail-on-empty-changeset \
-   --no-confirm-changeset \
-   --resolve-s3 \
-   --region eu-west-2 \
-   --capabilities CAPABILITY_IAM \
-   --parameter-overrides \
-   CodeSigningEnabled=false \
-   Environment=dev \
-   AuditEventNamePrefix=/common-cri-parameters/{{ pascalCase criName }}AuditEventNamePrefix \
-   CriIdentifier=/common-cri-parameters/{{ pascalCase criName }}CriIdentifier \
-   CommonStackName="$common_stack_name" \
-   SecretPrefix="$secret_prefix"
+  --no-fail-on-empty-changeset \
+  --no-confirm-changeset \
+  --resolve-s3 \
+  --s3-prefix "$stack_name" \
+  --region "${AWS_REGION:-eu-west-2}" \
+  --capabilities CAPABILITY_IAM \
+  --tags \
+  cri:component={{ kebabCase criName }} \
+  cri:stack-type=dev \
+  cri:application=Orange \
+  cri:deployment-source=manual \
+  --parameter-overrides \
+  ${common_stack_name:+CommonStackName=$common_stack_name} \
+  Environment=dev

--- a/lambda/templates/.github/workflows/check-pr.yml
+++ b/lambda/templates/.github/workflows/check-pr.yml
@@ -19,3 +19,25 @@ jobs:
   unit-tests:
     name: Run tests
     uses: ./.github/workflows/run-unit-tests.yml
+
+  mocked-tests:
+    name: Run tests
+    uses: ./.github/workflows/run-mocked-tests.yml
+
+  deploy:
+    name: Preview
+    uses: ./.github/workflows/deploy-branch.yml
+    permissions:
+      id-token: write
+      contents: read
+
+  aws-tests:
+    name: Run tests
+    needs: deploy
+    uses: ./.github/workflows/run-aws-tests.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      stack-name: $\{{ needs.deploy.outputs.stack-name }}
+      aws-region: $\{{ needs.deploy.outputs.aws-region }}

--- a/lambda/templates/.github/workflows/clean-up-deployments.yml.hbs
+++ b/lambda/templates/.github/workflows/clean-up-deployments.yml.hbs
@@ -1,0 +1,44 @@
+name: Clean up deployments
+run-name: Delete stale deployments
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every weekday at 10am
+    - cron: "0 10 * * 1-5"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency: cleanup-dev-$\{{ github.head_ref || github.ref_name }}
+
+jobs:
+  delete-stacks:
+    name: Delete stale stacks
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: $\{{ vars.DEPLOYMENT_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Get stale preview stacks
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@cd7d35dde348251237efbbaee5345e95adef0321
+        with:
+          threshold-days: 14
+          stack-name-filter: preview-{{ kebabCase criNameShort }}
+          stack-tag-filters: |
+            cri:deployment-source=github-actions
+            cri:stack-type=preview
+          description: preview
+          env-var-name: STACKS
+
+      - name: Delete stacks
+        if: $\{{ env.STACKS != null }}
+        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
+        with:
+          stack-names: $\{{ env.STACKS }}
+          verbose: true

--- a/lambda/templates/.github/workflows/delete-deployment.yml.hbs
+++ b/lambda/templates/.github/workflows/delete-deployment.yml.hbs
@@ -1,0 +1,36 @@
+name: Delete deployment
+run-name: $\{{ github.event.pull_request.title || format('Delete deployment [{0}]', github.head_ref || github.ref_name) }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency: deploy-development-$\{{ github.head_ref || github.ref_name }}
+
+jobs:
+  delete-stack:
+    name: Delete stack
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - name: Get stack name
+        uses: govuk-one-login/github-actions/beautify-branch-name@cd7d35dde348251237efbbaee5345e95adef0321
+        id: get-stack-name
+        with:
+          usage: Stack name
+          prefix: preview-{{ kebabCase criNameShort }}
+          length-limit: 128
+          verbose: false
+
+      - name: Delete stack
+        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
+        with:
+          stack-names: $\{{ steps.get-stack-name.outputs.pretty-branch-name }}
+          aws-role-arn: $\{{ vars.DEPLOYMENT_ROLE_ARN }}
+          verbose: true

--- a/lambda/templates/.github/workflows/deploy-branch.yml.hbs
+++ b/lambda/templates/.github/workflows/deploy-branch.yml.hbs
@@ -1,0 +1,63 @@
+name: Preview
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      stack-name:
+        description: The deployed stack name
+        value: $\{{ jobs.deploy.outputs.stack-name }}
+      aws-region:
+        description: The region in which the stack was deployed
+        value: $\{{ jobs.deploy.outputs.aws-region }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: Build SAM app
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Build SAM application
+        uses: govuk-one-login/github-actions/sam/build-application@cd7d35dde348251237efbbaee5345e95adef0321
+        id: build
+        with:
+          template: infrastructure/template.yaml
+          cache-key: {{ kebabCase criNameShort }}
+          pull-repository: true
+
+  deploy:
+    name: Deploy stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    concurrency:
+      group: deploy-development-$\{{ github.head_ref || github.ref_name }}
+    environment:
+      name: development
+      url: $\{{ steps.deploy.outputs.stack-url }}
+    outputs:
+      aws-region: $\{{ steps.deploy.outputs.aws-region }}
+      stack-name: $\{{ steps.deploy.outputs.stack-name }}
+    steps:
+      - name: Deploy stack
+        uses: govuk-one-login/github-actions/sam/deploy-stack@cd7d35dde348251237efbbaee5345e95adef0321
+        id: deploy
+        with:
+          sam-deployment-bucket: $\{{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
+          aws-role-arn: $\{{ vars.DEPLOYMENT_ROLE_ARN }}
+          stack-name-prefix: preview-{{ kebabCase criNameShort }}
+          cache-key: {{ kebabCase criNameShort }}
+          s3-prefix: preview
+          pull-repository: true
+          delete-failed-stack: true
+          tags: |
+            cri:component={{ kebabCase criName }}
+            cri:stack-type=preview
+            cri:application=Orange
+            cri:deployment-source=github-actions
+          parameters: |
+            Environment=dev

--- a/lambda/templates/.github/workflows/integration-tests.yml
+++ b/lambda/templates/.github/workflows/integration-tests.yml
@@ -1,0 +1,27 @@
+name: Integration tests
+
+on: workflow_dispatch
+permissions: {}
+
+jobs:
+  deploy:
+    name: Preview
+    uses: ./.github/workflows/deploy-branch.yml
+    permissions:
+      id-token: write
+      contents: read
+
+  aws-tests:
+    name: Integration tests
+    needs: deploy
+    uses: ./.github/workflows/run-aws-tests.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      stack-name: $\{{ needs.deploy.outputs.stack-name }}
+      aws-region: $\{{ needs.deploy.outputs.aws-region }}
+
+  mocked-tests:
+    name: Integration tests
+    uses: ./.github/workflows/run-mocked-tests.yml

--- a/lambda/templates/.github/workflows/run-aws-tests.yml
+++ b/lambda/templates/.github/workflows/run-aws-tests.yml
@@ -1,0 +1,50 @@
+name: AWS tests
+
+on:
+  workflow_call:
+    inputs:
+      stack-name: { required: true, type: string }
+      aws-region: { required: false, type: string }
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: aws-tests-$\{{ github.workflow }}-$\{{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: integration-tests
+    shell: bash
+
+jobs:
+  run-tests:
+    name: AWS
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v3
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --include-workspace-root
+
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: $\{{ vars.DEPLOYMENT_ROLE_ARN }}
+          aws-region: $\{{ inputs.aws-region }}
+
+      - name: Run tests
+        env:
+          AWS_REGION: $\{{ inputs.aws-region }}
+          STACK_NAME: $\{{ inputs.stack-name }}
+        run: npm run test:aws -- --config jest.config.ci.ts

--- a/lambda/templates/.github/workflows/run-mocked-tests.yml
+++ b/lambda/templates/.github/workflows/run-mocked-tests.yml
@@ -1,0 +1,35 @@
+name: Mocked tests
+
+on:
+  workflow_call:
+
+permissions: {}
+
+concurrency:
+  group: mocked-tests-$\{{ github.workflow }}-$\{{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: integration-tests
+    shell: bash
+
+jobs:
+  run-tests:
+    name: Mocked
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v3
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --include-workspace-root
+
+      - name: Run tests
+        run: npm run test:mocked -- --config jest.config.ci.ts

--- a/lambda/templates/config/package.json.hbs
+++ b/lambda/templates/config/package.json.hbs
@@ -11,7 +11,7 @@
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
     "sam:validate": "cd infrastructure && sam validate && sam validate --lint",
-    "sam:build": "sam build --template infrastructure/template.yaml --cached --parallel"
+    "sam:build": "npm run sam:validate && sam build --template infrastructure/template.yaml --cached --parallel"
   },
   "dependencies": {
     "@aws-lambda-powertools/commons": "1.14.2",

--- a/lambda/templates/config/package.json.hbs
+++ b/lambda/templates/config/package.json.hbs
@@ -11,7 +11,8 @@
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
     "sam:validate": "cd infrastructure && sam validate && sam validate --lint",
-    "sam:build": "npm run sam:validate && sam build --template infrastructure/template.yaml --cached --parallel"
+    "sam:build": "npm run sam:validate && sam build --template infrastructure/template.yaml --cached --parallel",
+    "deploy": "./deploy.sh"
   },
   "dependencies": {
     "@aws-lambda-powertools/commons": "1.14.2",

--- a/lambda/templates/lambdas/package.json.hbs
+++ b/lambda/templates/lambdas/package.json.hbs
@@ -7,6 +7,7 @@
     "unit": "jest --silent",
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
+    "deploy": "../../deploy.sh",
     "compile": "tsc"
   },
   "dependencies": {}

--- a/repo/templates/.github/workflows/check-pr.yml
+++ b/repo/templates/.github/workflows/check-pr.yml
@@ -3,20 +3,16 @@ name: Check PR
 on: pull_request
 permissions: read-all
 
-concurrency:
-  group: check-pr-$\{{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
-  unit-tests:
-    name: Run tests
-    uses: ./.github/workflows/unit-tests.yml
-
   pre-commit:
     name: pre-commit
     runs-on: ubuntu-latest
     steps:
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@b2b6fc5df355031fd08cef37fa13a93670a45899
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           all-files: true
+
+  unit-tests:
+    name: Run tests
+    uses: ./.github/workflows/run-unit-tests.yml

--- a/repo/templates/.github/workflows/run-unit-tests.yml
+++ b/repo/templates/.github/workflows/run-unit-tests.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           name: $\{{ inputs.coverage-artifact }}
           retention-days: 3
-          path: coverage
+          path: coverage/lcov.info

--- a/repo/templates/.github/workflows/scan-repo.yml
+++ b/repo/templates/.github/workflows/scan-repo.yml
@@ -17,7 +17,7 @@ permissions: read-all
 jobs:
   unit-tests:
     name: Test coverage
-    uses: ./.github/workflows/unit-tests.yml
+    uses: ./.github/workflows/run-unit-tests.yml
     with:
       coverage-report: true
 
@@ -26,8 +26,8 @@ jobs:
     needs: unit-tests
     runs-on: ubuntu-latest
     steps:
-      - name: Run a SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@b2b6fc5df355031fd08cef37fa13a93670a45899
+      - name: Run SonarCloud scan
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           coverage-artifact: $\{{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: $\{{ secrets.GITHUB_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Run a CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@b2b6fc5df355031fd08cef37fa13a93670a45899
+      - name: Run CodeQL scan
+        uses: govuk-one-login/github-actions/code-quality/codeql@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           languages: javascript-typescript

--- a/repo/templates/docs/SECURITY.md
+++ b/repo/templates/docs/SECURITY.md
@@ -1,3 +1,0 @@
-# Security Policy
-
-Vulnerability Disclosure Policy - https://www.gov.uk/help/report-vulnerability


### PR DESCRIPTION
Bring in changes from other repos to keep the templates in sync.

**Add deployment and integration test workflows to the lambda repos**
- Add a workflow generator to the lambda template

**Update the dev deployment script**
- Apply formatting
- Add tags to deployed stacks
- Use an S3 prefix
- Use the region from the environment, or use the default value if it's not set
- Set the `-u` flag to fail if any variable is missing a value
- Don't run `./gradlew clean` since this template is for TypeScript lambdas
- Remove unused parameter overrides
- Add an execution permission to the deploy script
  Ran `chmod +x api/templates/deploy.sh`

- Enable easy deployment to dev
  Derive stack name from the user's name and the CRI name if the name is not provided to the script.

  Add a deploy script to the package.json files so a stack can be quickly deployed from anywhere in the repo by simply running `npm run deploy`.

**Use the latest shared GitHub actions and update workflows**
- Update unit tests workflow file name
- Remove concurrency from the Check PR workflow
- Only archive the SonarCloud test coverage report

---

- Validate SAM template before building

- Remove SECURITY.md
  We now have https://github.com/govuk-one-login/.github/blob/main/SECURITY.md
  This file will default if there is no SECURITY.md file, so removing it will allow this to take precedence.