### PR TITLE
BAU: Use the full aws command instead of the whoami alias

### DIFF
--- a/api/templates/deploy.sh.hbs
+++ b/api/templates/deploy.sh.hbs
@@ -6,7 +6,7 @@ stack_name="${1:-}"
 common_stack_name="${2:-}"
 
 if ! [[ "$stack_name" ]]; then
-  [[ $(aws whoami --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
+  [[ $(aws sts get-caller-identity --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
   stack_name="$user-{{ kebabCase criNameShort }}"
   echo "» Using stack name '$stack_name'"
 fi


### PR DESCRIPTION
The alias might not be set up by default by the CLI so use the full command instead.