### PR TITLE
Updating GitHub provided action to new version

### DIFF
--- a/repo/templates/.github/workflows/run-unit-tests.yml
+++ b/repo/templates/.github/workflows/run-unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Archive coverage results
         if: $\{{ inputs.coverage-report }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: $\{{ inputs.coverage-artifact }}
           retention-days: 3

--- a/repo/templates/.github/workflows/scan-repo.yml
+++ b/repo/templates/.github/workflows/scan-repo.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
         with:
           coverage-artifact: $\{{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: $\{{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
EOL on the 5th December 2024

Also updated version of Sonar Cloud as it needs to use download-artifact v4 as well

https://govukverify.atlassian.net/browse/PSREDEV-1911

## Proposed changes
https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new
https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new

### What changed

Updated GH actions

### Why did it change

V3 being EOLed 5th Dec

### Issue tracking
https://govukverify.atlassian.net/browse/PSREDEV-1911