### PR TITLE
Update version of CodeQL to use v3 as v2 is EOL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,6 @@ jobs:
       security-events: write
     steps:
       - name: Run a CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/code-quality/codeql@d4ec36f4ed5ebfb93d4866b3322a70b27bb8f92f #31st Jan 2024
         with:
           languages: javascript-typescript

--- a/repo/templates/.github/workflows/scan-repo.yml
+++ b/repo/templates/.github/workflows/scan-repo.yml
@@ -40,6 +40,6 @@ jobs:
       security-events: write
     steps:
       - name: Run CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/code-quality/codeql@d4ec36f4ed5ebfb93d4866b3322a70b27bb8f92f #31st Jan 2024
         with:
           languages: javascript-typescript


### PR DESCRIPTION
## Proposed changes
Update CodeQL to more recent version

### What changed

Version of GH Action

### Why did it change

Old version is going EOL
