### PR TITLE
OJ-3003: Bump esbuild to resolve vuln

### DIFF
--- a/lambda/templates/config/package.json.hbs
+++ b/lambda/templates/config/package.json.hbs
@@ -19,7 +19,7 @@
     "@aws-lambda-powertools/logger": "1.14.2",
     "@aws-lambda-powertools/metrics": "1.14.2",
     "@aws-lambda-powertools/tracer": "1.14.2",
-    "esbuild": "0.19.5"
+    "esbuild": "0.25.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",


### PR DESCRIPTION
## Proposed changes

### What changed

Bump esbuild 0.19.5 -> 0.25.0

### Why did it change

Resolve https://github.com/govuk-one-login/ipv-cri-templates/security/dependabot/4

### Issue tracking

- [OJ-3003](https://govukverify.atlassian.net/browse/OJ-3003)


[OJ-3003]: https://govukverify.atlassian.net/browse/OJ-3003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ